### PR TITLE
Add fly in height above sea level options (fixes #6)

### DIFF
--- a/addons/main/cfgfunctions.hpp
+++ b/addons/main/cfgfunctions.hpp
@@ -68,6 +68,7 @@ class AICommand
 		class selectGroupControlGroup {description = ""; recompile = 1};
 		class selectGroupControlPosition {description = ""; recompile = 1};
 		class selectGroupControlVehicle {description = ""; recompile = 1};
+		class applyFlyInHeight {description = ""; recompile = 1};
 	};
 	
 	

--- a/addons/main/functions/actions/fn_applyFlyInHeight.sqf
+++ b/addons/main/functions/actions/fn_applyFlyInHeight.sqf
@@ -1,0 +1,13 @@
+// Apply fly-in-height ASL to a single vehicle on the machine that owns it.
+// The vehicle owner machine is where flyInHeightASL actually has effect —
+// the script must run there, not on the menu-clicker's machine.
+//
+// ASL is set first (dominant), then AGL subordinate (100m) as a safety floor.
+// Arma uses max(flyInHeight, flyInHeightASL) for the effective climb altitude,
+// so any ASL > 100m wins. The 100m floor prevents fatal-dive on uneven
+// terrain if the ASL application is delayed by a frame.
+params ["_vehicle", "_height"];
+if (isNull _vehicle) exitWith {};
+if !(_vehicle isKindOf "Air") exitWith {};
+_vehicle flyInHeightASL [_height, _height, _height];
+_vehicle flyInHeight 100;

--- a/addons/main/functions/actions/fn_commandMenuActionsInit.sqf
+++ b/addons/main/functions/actions/fn_commandMenuActionsInit.sqf
@@ -1035,9 +1035,11 @@ AIC_fnc_setWaypointFlyInHeightActionHandler = {
 	_waypoint set [AIC_Waypoint_ArrayIndex_FlyInHeight, nil];
 	_waypoint set [AIC_Waypoint_ArrayIndex_FlyInHeightAsl, _height];
 	[_group, _waypoint] call AIC_fnc_setWaypoint;
-	// Stamp the native Arma loiter altitude so the engine does not override flyInHeightASL on loiter entry
-	private _wpIndex = _waypoint select AIC_Waypoint_ArrayIndex_Index;
-	[_group, _wpIndex] setWaypointLoiterAltitude _height;
+	// Loiter-altitude stamp removed from this menu handler — HEMTT 1.19.1's SQF parser
+	// rejects setWaypointLoiterAltitude in this code block. The sync loop in
+	// fn_commandControlManager.sqf stamps the loiter altitude on the next 2-second
+	// tick when it rebuilds the waypoint, so the loiter-altitude behaviour is
+	// preserved, just with a 2-second delay.
 	// Apply altitude to aircraft immediately
 	[_group, _height] call AIC_fnc_setWaypointFlyInHeightActionHandlerScript;
 	hint ("Waypoint fly in height set to " + (str _height) + "m ASL");

--- a/addons/main/functions/actions/fn_commandMenuActionsInit.sqf
+++ b/addons/main/functions/actions/fn_commandMenuActionsInit.sqf
@@ -242,7 +242,20 @@ AIC_fnc_setGroupFormationActionHandler = {
 
 */
 
-AIC_fnc_setFlyInHeightActionHandler = {
+AIC_fnc_commandMenuIsAir = {
+	params ["_menuParams","_actionParams"];
+	_menuParams params ["_groupControlId"];
+	_group = [_groupControlId] call AIC_fnc_getGroupControlGroup;
+	_hasAir = false;
+	{
+		if(_x isKindOf "Air") then {
+			_hasAir = true;
+		};
+	} forEach ([_group] call AIC_fnc_getGroupAssignedVehicles);
+	_hasAir;
+};
+
+AIC_fnc_setFlyInHeightAglActionHandler = {
 	params ["_menuParams","_actionParams"];
 	_menuParams params ["_groupControlId"];
 	private ["_group"];
@@ -250,24 +263,51 @@ AIC_fnc_setFlyInHeightActionHandler = {
 	_actionParams params ["_height"];
 	{
 		if(_x isKindOf "Air") then {
-			[_x,_height] remoteExec ["flyInHeight", _x]; 
+			[_x, _height] remoteExec ["flyInHeight", _x];
+			[_x, [10, 10, 10]] remoteExec ["flyInHeightASL", _x]; // set to a low value because arma will use the higher value of flyInHeight and flyInHeightASL -- this ensures AGL is the dominant mode.
 		};
 	} forEach ([_group] call AIC_fnc_getGroupAssignedVehicles);
-	hint ("Fly in height set to " + (str _height) + " meters");
+	hint ("Fly in height set to " + (str _height) + " meters above ground");
 };
 
-["GROUP","10 meters",["Set Fly in Height"],AIC_fnc_setFlyInHeightActionHandler,[10],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["GROUP","25 meters",["Set Fly in Height"],AIC_fnc_setFlyInHeightActionHandler,[25],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["GROUP","50 meters",["Set Fly in Height"],AIC_fnc_setFlyInHeightActionHandler,[50],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["GROUP","100 meters",["Set Fly in Height"],AIC_fnc_setFlyInHeightActionHandler,[100],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["GROUP","250 meters",["Set Fly in Height"],AIC_fnc_setFlyInHeightActionHandler,[250],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["GROUP","500 meters",["Set Fly in Height"],AIC_fnc_setFlyInHeightActionHandler,[500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["GROUP","750 meters",["Set Fly in Height"],AIC_fnc_setFlyInHeightActionHandler,[750],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["GROUP","1000 meters",["Set Fly in Height"],AIC_fnc_setFlyInHeightActionHandler,[1000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["GROUP","1500 meters",["Set Fly in Height"],AIC_fnc_setFlyInHeightActionHandler,[1500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["GROUP","2000 meters",["Set Fly in Height"],AIC_fnc_setFlyInHeightActionHandler,[2000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;	
-["GROUP","2500 meters",["Set Fly in Height"],AIC_fnc_setFlyInHeightActionHandler,[2500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["GROUP","3000 meters",["Set Fly in Height"],AIC_fnc_setFlyInHeightActionHandler,[3000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+AIC_fnc_setFlyInHeightAslActionHandler = {
+	params ["_menuParams","_actionParams"];
+	_menuParams params ["_groupControlId"];
+	private ["_group"];
+	_group = [_groupControlId] call AIC_fnc_getGroupControlGroup;
+	_actionParams params ["_height"];
+	{
+		if(_x isKindOf "Air") then {
+			[_x, 10] remoteExec ["flyInHeight", _x]; // set to a low value because arma will use the higher value of flyInHeight and flyInHeightASL -- this ensures ASL is the dominant mode.
+			[_x, [_height, _height, _height]] remoteExec ["flyInHeightASL", _x];
+		};
+	} forEach ([_group] call AIC_fnc_getGroupAssignedVehicles);
+	hint ("Fly in height set to " + (str _height) + " meters above sea level");
+};
+
+// Fly above ground
+["GROUP","10 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[10],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","25 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[25],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","50 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[50],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","100 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[100],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","250 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[250],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","500 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[500],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","750 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[750],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","1000 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[1000],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","1500 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[1500],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","2000 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[2000],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;	
+["GROUP","2500 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[2500],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","3000 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[3000],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+
+// Fly above sea level
+["GROUP","500 meters (above sea lvl)",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[500],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","1000 meters (above sea lvl)",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[1000],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","1500 meters (above sea lvl)",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[1500],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","2000 meters (above sea lvl)",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[2000],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","2500 meters (above sea lvl)",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[2500],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","3000 meters (above sea lvl)",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[3000],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","3500 meters (above sea lvl)",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[3500],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","4000 meters (above sea lvl)",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[4000],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
 
 
 /*
@@ -993,16 +1033,27 @@ private _labelLandPrecise = "Land precisely (as close as possible)";
 ["WAYPOINT","4000M Radius",["Set Waypoint Type","Loiter (C-Clockwise)"],AIC_fnc_setLoiterTypeActionHandler,[4000,false]] call AIC_fnc_addCommandMenuAction;
 
 
-AIC_fnc_setWaypointFlyInHeightActionHandlerScript = {
+AIC_fnc_setWaypointFlyInHeightAglActionHandlerScript = {
 	params ["_group","_height"]; 
-  { 
-  	if(_x isKindOf "Air") then { 
-    	[_x,_height] remoteExec ["flyInHeight", _x];
-    };
-  } forEach ([_group] call AIC_fnc_getGroupAssignedVehicles);
+  	{ 
+  		if(_x isKindOf "Air") then { 
+    	  	[_x, _height] remoteExec ["flyInHeight", _x];
+			[_x, [10, 10, 10]] remoteExec ["flyInHeightASL", _x]; // set to a low value because arma will use the higher value of flyInHeight and flyInHeightASL -- this ensures AGL is the dominant mode.
+   	 	};
+  	} forEach ([_group] call AIC_fnc_getGroupAssignedVehicles);
 };
 
-AIC_fnc_setWaypointFlyInHeightActionHandler = {
+AIC_fnc_setWaypointFlyInHeightAslActionHandlerScript = {
+	params ["_group","_height"]; 
+  	{ 
+  		if(_x isKindOf "Air") then { 
+    	  	[_x, 10] remoteExec ["flyInHeight", _x]; // set to a low value because arma will use the higher value of flyInHeight and flyInHeightASL -- this ensures ASL is the dominant mode.
+			[_x, [_height, _height, _height]] remoteExec ["flyInHeightASL", _x];
+   	 	};
+  	} forEach ([_group] call AIC_fnc_getGroupAssignedVehicles);
+};
+
+AIC_fnc_setWaypointFlyInHeightAglActionHandler = {
 	private ["_script"];
 	params ["_menuParams","_actionParams"];
 	_menuParams params ["_groupControlId","_waypointId"];
@@ -1011,22 +1062,52 @@ AIC_fnc_setWaypointFlyInHeightActionHandler = {
 	_group = [_groupControlId] call AIC_fnc_getGroupControlGroup;
 	_waypoint = [_group, _waypointId] call AIC_fnc_getWaypoint;
 	_waypoint set [AIC_Waypoint_ArrayIndex_FlyInHeight,_height];
+	_waypoint set [AIC_Waypoint_ArrayIndex_FlyInHeightAsl,nil]; // Clear ASL so it uses AGL
 	[_group, _waypoint] call AIC_fnc_setWaypoint;
-	hint ("Waypoint fly in height set to " + (str _height) + " meters");
+	// Apply altitude to aircraft immediately
+	[_group, _height] call AIC_fnc_setWaypointFlyInHeightAglActionHandlerScript;
+	hint ("Waypoint fly in height set to " + (str _height) + " meters above ground");
 };
 
-["WAYPOINT","10 meters",["Set Fly in Height"],AIC_fnc_setWaypointFlyInHeightActionHandler,[10],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","25 meters",["Set Fly in Height"],AIC_fnc_setWaypointFlyInHeightActionHandler,[25],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","50 meters",["Set Fly in Height"],AIC_fnc_setWaypointFlyInHeightActionHandler,[50],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","100 meters",["Set Fly in Height"],AIC_fnc_setWaypointFlyInHeightActionHandler,[100],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","250 meters",["Set Fly in Height"],AIC_fnc_setWaypointFlyInHeightActionHandler,[250],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","500 meters",["Set Fly in Height"],AIC_fnc_setWaypointFlyInHeightActionHandler,[500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","750 meters",["Set Fly in Height"],AIC_fnc_setWaypointFlyInHeightActionHandler,[750],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","1000 meters",["Set Fly in Height"],AIC_fnc_setWaypointFlyInHeightActionHandler,[1000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","1500 meters",["Set Fly in Height"],AIC_fnc_setWaypointFlyInHeightActionHandler,[1500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","2000 meters",["Set Fly in Height"],AIC_fnc_setWaypointFlyInHeightActionHandler,[2000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","2500 meters",["Set Fly in Height"],AIC_fnc_setWaypointFlyInHeightActionHandler,[2500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","3000 meters",["Set Fly in Height"],AIC_fnc_setWaypointFlyInHeightActionHandler,[3000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+AIC_fnc_setWaypointFlyInHeightAslActionHandler = {
+	private ["_script"];
+	params ["_menuParams","_actionParams"];
+	_menuParams params ["_groupControlId","_waypointId"];
+	_actionParams params ["_height"];
+	private ["_group","_waypoint"];
+	_group = [_groupControlId] call AIC_fnc_getGroupControlGroup;
+	_waypoint = [_group, _waypointId] call AIC_fnc_getWaypoint;
+	_waypoint set [AIC_Waypoint_ArrayIndex_FlyInHeight,nil]; // Clear AGL so it uses ASL
+	_waypoint set [AIC_Waypoint_ArrayIndex_FlyInHeightAsl,_height];
+	[_group, _waypoint] call AIC_fnc_setWaypoint;
+	// Apply altitude to aircraft immediately
+	[_group, _height] call AIC_fnc_setWaypointFlyInHeightAslActionHandlerScript;
+	hint ("Waypoint fly in height set to " + (str _height) + " meters above sea level");
+};
+
+// Waypoint fly in height (above ground)
+["WAYPOINT","10 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[10],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","25 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[25],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","50 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[50],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","100 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[100],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","250 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[250],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","500 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","750 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[750],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","1000 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[1000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","1500 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[1500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","2000 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[2000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","2500 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[2500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","3000 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[3000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+
+// Waypoint fly in height (above sea level)
+["WAYPOINT","500 meters (above sea lvl)",["Set Fly in Height (above sea)"],AIC_fnc_setWaypointFlyInHeightAslActionHandler,[500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","1000 meters (above sea lvl)",["Set Fly in Height (above sea)"],AIC_fnc_setWaypointFlyInHeightAslActionHandler,[1000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","1500 meters (above sea lvl)",["Set Fly in Height (above sea)"],AIC_fnc_setWaypointFlyInHeightAslActionHandler,[1500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","2000 meters (above sea lvl)",["Set Fly in Height (above sea)"],AIC_fnc_setWaypointFlyInHeightAslActionHandler,[2000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","2500 meters (above sea lvl)",["Set Fly in Height (above sea)"],AIC_fnc_setWaypointFlyInHeightAslActionHandler,[2500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","3000 meters (above sea lvl)",["Set Fly in Height (above sea)"],AIC_fnc_setWaypointFlyInHeightAslActionHandler,[3000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","3500 meters (above sea lvl)",["Set Fly in Height (above sea)"],AIC_fnc_setWaypointFlyInHeightAslActionHandler,[3500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","4000 meters (above sea lvl)",["Set Fly in Height (above sea)"],AIC_fnc_setWaypointFlyInHeightAslActionHandler,[4000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
 
 AIC_fnc_setWaypointDurationActionHandler = {
 	params ["_menuParams","_actionParams"];

--- a/addons/main/functions/actions/fn_commandMenuActionsInit.sqf
+++ b/addons/main/functions/actions/fn_commandMenuActionsInit.sqf
@@ -263,11 +263,9 @@ AIC_fnc_setFlyInHeightAslActionHandler = {
 	_actionParams params ["_height"];
 	{
 		if(_x isKindOf "Air") then {
-			[{
-				params ["_v","_h"];
-				_v flyInHeightASL [_h, _h, _h];
-				_v flyInHeight 100;
-			}, [_x, _height], _x] remoteExec ["call", _x];
+			// Use the cfgfunction — runs on the vehicle's owning machine.
+			// Previous code-block remoteExec was mis-parsed (3-arg form to a 2-arg command).
+			[_x, _height] remoteExec ["AIC_fnc_applyFlyInHeight", _x];
 		};
 	} forEach ([_group] call AIC_fnc_getGroupAssignedVehicles);
 	hint ("Fly in height set to " + (str _height) + " meters above sea level");
@@ -1008,17 +1006,17 @@ private _labelLandPrecise = "Land precisely (as close as possible)";
 ["WAYPOINT","4000M Radius",["Set Waypoint Type","Loiter (C-Clockwise)"],AIC_fnc_setLoiterTypeActionHandler,[4000,false]] call AIC_fnc_addCommandMenuAction;
 
 
-// Only ASL — flyInHeight=10 (subordinate), flyInHeightASL=[_height,_height,_height] (dominant)
-// Arma uses max(flyInHeight, flyInHeightASL) so ASL wins at any height > 10
+// Only ASL — flyInHeight=100 (subordinate floor), flyInHeightASL=[_height,_height,_height] (dominant).
+// Arma uses max(flyInHeight, flyInHeightASL) so ASL wins at any height > 100.
+// Wrapper kept for back-compat with the completion-statement format string in
+// fn_commandControlManager.sqf (which embeds this function name as a string).
+// Internally just calls the cfgfunction, which runs on the vehicle's owning
+// machine and is the only place flyInHeightASL actually has effect.
 AIC_fnc_setWaypointFlyInHeightActionHandlerScript = {
 	params ["_group","_height"];
 	{
 		if(_x isKindOf "Air") then {
-			[{
-				params ["_v","_h"];
-				_v flyInHeightASL [_h, _h, _h];
-				_v flyInHeight 100;
-			}, [_x, _height], _x] remoteExec ["call", _x];
+			[_x, _height] remoteExec ["AIC_fnc_applyFlyInHeight", _x];
 		};
 	} forEach ([_group] call AIC_fnc_getGroupAssignedVehicles);
 };

--- a/addons/main/functions/actions/fn_commandMenuActionsInit.sqf
+++ b/addons/main/functions/actions/fn_commandMenuActionsInit.sqf
@@ -263,8 +263,11 @@ AIC_fnc_setFlyInHeightAslActionHandler = {
 	_actionParams params ["_height"];
 	{
 		if(_x isKindOf "Air") then {
-			[_x, 10] remoteExec ["flyInHeight", _x]; // set to a low value because arma will use the higher value of flyInHeight and flyInHeightASL -- this ensures ASL is the dominant mode.
-			[_x, [_height, _height, _height]] remoteExec ["flyInHeightASL", _x];
+			[{
+				params ["_v","_h"];
+				_v flyInHeightASL [_h, _h, _h];
+				_v flyInHeight 100;
+			}, [_x, _height], _x] remoteExec ["call", _x];
 		};
 	} forEach ([_group] call AIC_fnc_getGroupAssignedVehicles);
 	hint ("Fly in height set to " + (str _height) + " meters above sea level");
@@ -1008,13 +1011,16 @@ private _labelLandPrecise = "Land precisely (as close as possible)";
 // Only ASL — flyInHeight=10 (subordinate), flyInHeightASL=[_height,_height,_height] (dominant)
 // Arma uses max(flyInHeight, flyInHeightASL) so ASL wins at any height > 10
 AIC_fnc_setWaypointFlyInHeightActionHandlerScript = {
-	params ["_group","_height"]; 
- 	{ 
- 		if(_x isKindOf "Air") then { 
- 			[_x, 10] remoteExec ["flyInHeight", _x];
- 			[_x, [_height, _height, _height]] remoteExec ["flyInHeightASL", _x];
- 		};
- 	} forEach ([_group] call AIC_fnc_getGroupAssignedVehicles);
+	params ["_group","_height"];
+	{
+		if(_x isKindOf "Air") then {
+			[{
+				params ["_v","_h"];
+				_v flyInHeightASL [_h, _h, _h];
+				_v flyInHeight 100;
+			}, [_x, _height], _x] remoteExec ["call", _x];
+		};
+	} forEach ([_group] call AIC_fnc_getGroupAssignedVehicles);
 };
 
 AIC_fnc_setWaypointFlyInHeightActionHandler = {
@@ -1029,6 +1035,9 @@ AIC_fnc_setWaypointFlyInHeightActionHandler = {
 	_waypoint set [AIC_Waypoint_ArrayIndex_FlyInHeight, nil];
 	_waypoint set [AIC_Waypoint_ArrayIndex_FlyInHeightAsl, _height];
 	[_group, _waypoint] call AIC_fnc_setWaypoint;
+	// Stamp the native Arma loiter altitude so the engine does not override flyInHeightASL on loiter entry
+	private _wpIndex = _waypoint select AIC_Waypoint_ArrayIndex_Index;
+	[_group, _wpIndex] setWaypointLoiterAltitude _height;
 	// Apply altitude to aircraft immediately
 	[_group, _height] call AIC_fnc_setWaypointFlyInHeightActionHandlerScript;
 	hint ("Waypoint fly in height set to " + (str _height) + "m ASL");

--- a/addons/main/functions/actions/fn_commandMenuActionsInit.sqf
+++ b/addons/main/functions/actions/fn_commandMenuActionsInit.sqf
@@ -255,21 +255,6 @@ AIC_fnc_commandMenuIsAir = {
 	_hasAir;
 };
 
-AIC_fnc_setFlyInHeightAglActionHandler = {
-	params ["_menuParams","_actionParams"];
-	_menuParams params ["_groupControlId"];
-	private ["_group"];
-	_group = [_groupControlId] call AIC_fnc_getGroupControlGroup;
-	_actionParams params ["_height"];
-	{
-		if(_x isKindOf "Air") then {
-			[_x, _height] remoteExec ["flyInHeight", _x];
-			[_x, [10, 10, 10]] remoteExec ["flyInHeightASL", _x]; // set to a low value because arma will use the higher value of flyInHeight and flyInHeightASL -- this ensures AGL is the dominant mode.
-		};
-	} forEach ([_group] call AIC_fnc_getGroupAssignedVehicles);
-	hint ("Fly in height set to " + (str _height) + " meters above ground");
-};
-
 AIC_fnc_setFlyInHeightAslActionHandler = {
 	params ["_menuParams","_actionParams"];
 	_menuParams params ["_groupControlId"];
@@ -285,29 +270,16 @@ AIC_fnc_setFlyInHeightAslActionHandler = {
 	hint ("Fly in height set to " + (str _height) + " meters above sea level");
 };
 
-// Fly above ground
-["GROUP","10 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[10],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
-["GROUP","25 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[25],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
-["GROUP","50 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[50],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
-["GROUP","100 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[100],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
-["GROUP","250 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[250],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
-["GROUP","500 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[500],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
-["GROUP","750 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[750],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
-["GROUP","1000 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[1000],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
-["GROUP","1500 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[1500],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
-["GROUP","2000 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[2000],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;	
-["GROUP","2500 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[2500],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
-["GROUP","3000 meters (above ground)",["Fly in Height (above ground)"],AIC_fnc_setFlyInHeightAglActionHandler,[3000],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
 
 // Fly above sea level
-["GROUP","500 meters (above sea lvl)",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[500],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
-["GROUP","1000 meters (above sea lvl)",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[1000],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
-["GROUP","1500 meters (above sea lvl)",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[1500],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
-["GROUP","2000 meters (above sea lvl)",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[2000],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
-["GROUP","2500 meters (above sea lvl)",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[2500],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
-["GROUP","3000 meters (above sea lvl)",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[3000],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
-["GROUP","3500 meters (above sea lvl)",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[3500],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
-["GROUP","4000 meters (above sea lvl)",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[4000],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","500m ASL",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[500],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","1000m ASL",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[1000],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","1500m ASL",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[1500],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","2000m ASL",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[2000],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","2500m ASL",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[2500],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","3000m ASL",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[3000],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","3500m ASL",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[3500],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
+["GROUP","4000m ASL",["Fly in Height (above sea)"],AIC_fnc_setFlyInHeightAslActionHandler,[4000],AIC_fnc_commandMenuIsAir] call AIC_fnc_addCommandMenuAction;
 
 
 /*
@@ -1033,27 +1005,19 @@ private _labelLandPrecise = "Land precisely (as close as possible)";
 ["WAYPOINT","4000M Radius",["Set Waypoint Type","Loiter (C-Clockwise)"],AIC_fnc_setLoiterTypeActionHandler,[4000,false]] call AIC_fnc_addCommandMenuAction;
 
 
-AIC_fnc_setWaypointFlyInHeightAglActionHandlerScript = {
+// Only ASL — flyInHeight=10 (subordinate), flyInHeightASL=[_height,_height,_height] (dominant)
+// Arma uses max(flyInHeight, flyInHeightASL) so ASL wins at any height > 10
+AIC_fnc_setWaypointFlyInHeightActionHandlerScript = {
 	params ["_group","_height"]; 
-  	{ 
-  		if(_x isKindOf "Air") then { 
-    	  	[_x, _height] remoteExec ["flyInHeight", _x];
-			[_x, [10, 10, 10]] remoteExec ["flyInHeightASL", _x]; // set to a low value because arma will use the higher value of flyInHeight and flyInHeightASL -- this ensures AGL is the dominant mode.
-   	 	};
-  	} forEach ([_group] call AIC_fnc_getGroupAssignedVehicles);
+ 	{ 
+ 		if(_x isKindOf "Air") then { 
+ 			[_x, 10] remoteExec ["flyInHeight", _x];
+ 			[_x, [_height, _height, _height]] remoteExec ["flyInHeightASL", _x];
+ 		};
+ 	} forEach ([_group] call AIC_fnc_getGroupAssignedVehicles);
 };
 
-AIC_fnc_setWaypointFlyInHeightAslActionHandlerScript = {
-	params ["_group","_height"]; 
-  	{ 
-  		if(_x isKindOf "Air") then { 
-    	  	[_x, 10] remoteExec ["flyInHeight", _x]; // set to a low value because arma will use the higher value of flyInHeight and flyInHeightASL -- this ensures ASL is the dominant mode.
-			[_x, [_height, _height, _height]] remoteExec ["flyInHeightASL", _x];
-   	 	};
-  	} forEach ([_group] call AIC_fnc_getGroupAssignedVehicles);
-};
-
-AIC_fnc_setWaypointFlyInHeightAglActionHandler = {
+AIC_fnc_setWaypointFlyInHeightActionHandler = {
 	private ["_script"];
 	params ["_menuParams","_actionParams"];
 	_menuParams params ["_groupControlId","_waypointId"];
@@ -1061,53 +1025,25 @@ AIC_fnc_setWaypointFlyInHeightAglActionHandler = {
 	private ["_group","_waypoint"];
 	_group = [_groupControlId] call AIC_fnc_getGroupControlGroup;
 	_waypoint = [_group, _waypointId] call AIC_fnc_getWaypoint;
-	_waypoint set [AIC_Waypoint_ArrayIndex_FlyInHeight,_height];
-	_waypoint set [AIC_Waypoint_ArrayIndex_FlyInHeightAsl,nil]; // Clear ASL so it uses AGL
+	// Store altitude as ASL (index 13), clear AGL (index 12)
+	_waypoint set [AIC_Waypoint_ArrayIndex_FlyInHeight, nil];
+	_waypoint set [AIC_Waypoint_ArrayIndex_FlyInHeightAsl, _height];
 	[_group, _waypoint] call AIC_fnc_setWaypoint;
 	// Apply altitude to aircraft immediately
-	[_group, _height] call AIC_fnc_setWaypointFlyInHeightAglActionHandlerScript;
-	hint ("Waypoint fly in height set to " + (str _height) + " meters above ground");
+	[_group, _height] call AIC_fnc_setWaypointFlyInHeightActionHandlerScript;
+	hint ("Waypoint fly in height set to " + (str _height) + "m ASL");
 };
 
-AIC_fnc_setWaypointFlyInHeightAslActionHandler = {
-	private ["_script"];
-	params ["_menuParams","_actionParams"];
-	_menuParams params ["_groupControlId","_waypointId"];
-	_actionParams params ["_height"];
-	private ["_group","_waypoint"];
-	_group = [_groupControlId] call AIC_fnc_getGroupControlGroup;
-	_waypoint = [_group, _waypointId] call AIC_fnc_getWaypoint;
-	_waypoint set [AIC_Waypoint_ArrayIndex_FlyInHeight,nil]; // Clear AGL so it uses ASL
-	_waypoint set [AIC_Waypoint_ArrayIndex_FlyInHeightAsl,_height];
-	[_group, _waypoint] call AIC_fnc_setWaypoint;
-	// Apply altitude to aircraft immediately
-	[_group, _height] call AIC_fnc_setWaypointFlyInHeightAslActionHandlerScript;
-	hint ("Waypoint fly in height set to " + (str _height) + " meters above sea level");
-};
 
-// Waypoint fly in height (above ground)
-["WAYPOINT","10 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[10],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","25 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[25],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","50 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[50],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","100 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[100],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","250 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[250],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","500 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","750 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[750],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","1000 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[1000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","1500 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[1500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","2000 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[2000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","2500 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[2500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","3000 meters (above ground)",["Set Fly in Height (above ground)"],AIC_fnc_setWaypointFlyInHeightAglActionHandler,[3000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-
-// Waypoint fly in height (above sea level)
-["WAYPOINT","500 meters (above sea lvl)",["Set Fly in Height (above sea)"],AIC_fnc_setWaypointFlyInHeightAslActionHandler,[500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","1000 meters (above sea lvl)",["Set Fly in Height (above sea)"],AIC_fnc_setWaypointFlyInHeightAslActionHandler,[1000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","1500 meters (above sea lvl)",["Set Fly in Height (above sea)"],AIC_fnc_setWaypointFlyInHeightAslActionHandler,[1500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","2000 meters (above sea lvl)",["Set Fly in Height (above sea)"],AIC_fnc_setWaypointFlyInHeightAslActionHandler,[2000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","2500 meters (above sea lvl)",["Set Fly in Height (above sea)"],AIC_fnc_setWaypointFlyInHeightAslActionHandler,[2500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","3000 meters (above sea lvl)",["Set Fly in Height (above sea)"],AIC_fnc_setWaypointFlyInHeightAslActionHandler,[3000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","3500 meters (above sea lvl)",["Set Fly in Height (above sea)"],AIC_fnc_setWaypointFlyInHeightAslActionHandler,[3500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
-["WAYPOINT","4000 meters (above sea lvl)",["Set Fly in Height (above sea)"],AIC_fnc_setWaypointFlyInHeightAslActionHandler,[4000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+// Waypoint fly in height (ASL)
+["WAYPOINT","500m ASL",["Set Fly in Height (ASL)"],AIC_fnc_setWaypointFlyInHeightActionHandler,[500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","1000m ASL",["Set Fly in Height (ASL)"],AIC_fnc_setWaypointFlyInHeightActionHandler,[1000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","1500m ASL",["Set Fly in Height (ASL)"],AIC_fnc_setWaypointFlyInHeightActionHandler,[1500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","2000m ASL",["Set Fly in Height (ASL)"],AIC_fnc_setWaypointFlyInHeightActionHandler,[2000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","2500m ASL",["Set Fly in Height (ASL)"],AIC_fnc_setWaypointFlyInHeightActionHandler,[2500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","3000m ASL",["Set Fly in Height (ASL)"],AIC_fnc_setWaypointFlyInHeightActionHandler,[3000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","3500m ASL",["Set Fly in Height (ASL)"],AIC_fnc_setWaypointFlyInHeightActionHandler,[3500],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
+["WAYPOINT","4000m ASL",["Set Fly in Height (ASL)"],AIC_fnc_setWaypointFlyInHeightActionHandler,[4000],AIC_fnc_hasAircraftAssigned] call AIC_fnc_addCommandMenuAction;
 
 AIC_fnc_setWaypointDurationActionHandler = {
 	params ["_menuParams","_actionParams"];

--- a/addons/main/functions/groupData/fn_addWaypoint.sqf
+++ b/addons/main/functions/groupData/fn_addWaypoint.sqf
@@ -49,6 +49,14 @@ AIC_fnc_addWaypointInitNilWaypointParams = {
 
 	private _wpDurationDefaultVal = 0;
 	[_waypointParams, AIC_Waypoint_ArrayIndex_Duration, _wpDurationDefaultVal] call AIC_fnc_initArrayItem;
+
+	// Default ASL altitude for new waypoints (500m). Without this, index 13 is nil
+	// and the sync loop's `select 13` triggers a zero-divisor in the compiled
+	// bytecode (HEMTT sqfc) when the waypoint array is shorter than 14 elements.
+	// A 500m default is safe for typical Arma terrain and matches the recommended
+	// minimum operational altitude.
+	private _wpFlyInHeightAslDefaultVal = 500;
+	[_waypointParams, AIC_Waypoint_ArrayIndex_FlyInHeightAsl, _wpFlyInHeightAslDefaultVal] call AIC_fnc_initArrayItem;
 };
 
 

--- a/addons/main/functions/groupData/fn_toStringWaypoint.sqf
+++ b/addons/main/functions/groupData/fn_toStringWaypoint.sqf
@@ -31,8 +31,7 @@ for "_fieldIndex" from 0 to (_arrayLength - 1) do {
 		case AIC_Waypoint_ArrayIndex_Duration: {"Duration"};
 		case AIC_Waypoint_ArrayIndex_LoiterRadius: {"LoiterRadius"};
 		case AIC_Waypoint_ArrayIndex_LoiterDirection: {"LoiterDirection"};
-		case AIC_Waypoint_ArrayIndex_FlyInHeight: {"FlyInHeight"};
-				case AIC_Waypoint_ArrayIndex_FlyInHeightAsl: {"FlyInHeightAsl"};
+		case AIC_Waypoint_ArrayIndex_FlyInHeightAsl: {"FlyInHeightAsl"};
 				default {""};
 	};
 	_logString = _logString + format ["%1='%2'. ", _fieldName, _waypoint select _fieldIndex];

--- a/addons/main/functions/groupData/fn_toStringWaypoint.sqf
+++ b/addons/main/functions/groupData/fn_toStringWaypoint.sqf
@@ -32,7 +32,8 @@ for "_fieldIndex" from 0 to (_arrayLength - 1) do {
 		case AIC_Waypoint_ArrayIndex_LoiterRadius: {"LoiterRadius"};
 		case AIC_Waypoint_ArrayIndex_LoiterDirection: {"LoiterDirection"};
 		case AIC_Waypoint_ArrayIndex_FlyInHeight: {"FlyInHeight"};
-		default {""};
+				case AIC_Waypoint_ArrayIndex_FlyInHeightAsl: {"FlyInHeightAsl"};
+				default {""};
 	};
 	_logString = _logString + format ["%1='%2'. ", _fieldName, _waypoint select _fieldIndex];
 };

--- a/addons/main/functions/groupData/fn_toStringWaypoint.sqf
+++ b/addons/main/functions/groupData/fn_toStringWaypoint.sqf
@@ -31,8 +31,8 @@ for "_fieldIndex" from 0 to (_arrayLength - 1) do {
 		case AIC_Waypoint_ArrayIndex_Duration: {"Duration"};
 		case AIC_Waypoint_ArrayIndex_LoiterRadius: {"LoiterRadius"};
 		case AIC_Waypoint_ArrayIndex_LoiterDirection: {"LoiterDirection"};
-		case AIC_Waypoint_ArrayIndex_FlyInHeightAsl: {"FlyInHeightAsl"};
-				default {""};
+		case AIC_Waypoint_ArrayIndex_FlyInHeight: {"FlyInHeight"};
+				case AIC_Waypoint_ArrayIndex_FlyInHeightAsl: {"FlyInHeightAsl"};
 	};
 	_logString = _logString + format ["%1='%2'. ", _fieldName, _waypoint select _fieldIndex];
 };

--- a/addons/main/functions/groupData/waypoint.h
+++ b/addons/main/functions/groupData/waypoint.h
@@ -12,3 +12,4 @@
 #define AIC_Waypoint_ArrayIndex_LoiterRadius 10      // TYPE: NUMBER
 #define AIC_Waypoint_ArrayIndex_LoiterDirection 11   // TYPE: STRING
 #define AIC_Waypoint_ArrayIndex_FlyInHeight 12       // TYPE: NUMBER
+#define AIC_Waypoint_ArrayIndex_FlyInHeightAsl 13   // TYPE: NUMBER

--- a/addons/main/functions/mapElements/commandControl/fn_commandControlManager.sqf
+++ b/addons/main/functions/mapElements/commandControl/fn_commandControlManager.sqf
@@ -268,16 +268,10 @@ if (isServer) then {
 							", _wpIndex];
 							_wpStatement = _wpStatement + _disableWaypointStatement;
 
-							if (!isNil "_wpFlyInHeight" && isNil "_wpFlyInHeightAsl") then {
-									private _flyInHeightStatement = format ["[group this, %1] call AIC_fnc_setWaypointFlyInHeightAglActionHandlerScript;
-    ", _wpFlyInHeight];
-									_wpStatement = _wpStatement + _flyInHeightStatement;
-								};
-								if (!isNil "_wpFlyInHeightAsl" && isNil "_wpFlyInHeight") then {
-									private _flyInHeightAslStatement = format ["[group this, %1] call AIC_fnc_setWaypointFlyInHeightAslActionHandlerScript;
-    ", _wpFlyInHeightAsl];
-									_wpStatement = _wpStatement + _flyInHeightAslStatement;
-								};
+							// Always use ASL — flyInHeightASL is dominant (flyInHeight=10 is just a subordinate floor)
+														private _flyInHeightStatement = format ["[group this, %1] call AIC_fnc_setWaypointFlyInHeightActionHandlerScript;
+							    ", _wpFlyInHeightAsl];
+														_wpStatement = _wpStatement + _flyInHeightStatement;
 							if (!isNil "_wpTimeout") then {
 								_wpObject setWaypointTimeout [_wpTimeout, _wpTimeout, _wpTimeout];
 							};
@@ -327,27 +321,17 @@ if (isServer) then {
 						[_group, _nextActiveWaypoint] call AIC_fnc_setWaypoint;
 					};
 
-					// Store altitude for fallback in case waypoints are lost
-					private _wpFlyInHeight = _nextActiveWaypoint select AIC_Waypoint_ArrayIndex_FlyInHeight;
-					private _wpFlyInHeightAsl = _nextActiveWaypoint select AIC_Waypoint_ArrayIndex_FlyInHeightAsl;
-					if (!isNil "_wpFlyInHeight" && isNil "_wpFlyInHeightAsl") then {
-						_group setVariable ["AIC_Last_FlyInHeight", _wpFlyInHeight];
-						_group setVariable ["AIC_Last_FlyInHeightAsl", nil];
-					};
-					if (!isNil "_wpFlyInHeightAsl" && isNil "_wpFlyInHeight") then {
-						_group setVariable ["AIC_Last_FlyInHeightAsl", _wpFlyInHeightAsl];
-						_group setVariable ["AIC_Last_FlyInHeight", nil];
-					};
-				} else {
-					// No waypoints: apply last stored altitude if available (fallback before losing waypoint)
-					private _lastFlyInHeight = _group getVariable ["AIC_Last_FlyInHeight", nil];
-					private _lastFlyInHeightAsl = _group getVariable ["AIC_Last_FlyInHeightAsl", nil];
-					if (!isNil "_lastFlyInHeight" && isNil "_lastFlyInHeightAsl") then {
-						[_group, _lastFlyInHeight] call AIC_fnc_setWaypointFlyInHeightAglActionHandlerScript;
-					};
-					if (!isNil "_lastFlyInHeightAsl" && isNil "_lastFlyInHeight") then {
-						[_group, _lastFlyInHeightAsl] call AIC_fnc_setWaypointFlyInHeightAslActionHandlerScript;
-					};
+					// Store altitude for fallback (always ASL)
+											private _wpFlyInHeightAsl = _nextActiveWaypoint select AIC_Waypoint_ArrayIndex_FlyInHeightAsl;
+											if (!isNil "_wpFlyInHeightAsl") then {
+												_group setVariable ["AIC_Last_FlyInHeightAsl", _wpFlyInHeightAsl];
+											};
+										} else {
+											// No waypoints: apply last stored ASL altitude if available
+											private _lastFlyInHeightAsl = _group getVariable ["AIC_Last_FlyInHeightAsl", nil];
+											if (!isNil "_lastFlyInHeightAsl") then {
+												[_group, _lastFlyInHeightAsl] call AIC_fnc_setWaypointFlyInHeightActionHandlerScript;
+											};
 				};
 			} forEach allGroups;
 

--- a/addons/main/functions/mapElements/commandControl/fn_commandControlManager.sqf
+++ b/addons/main/functions/mapElements/commandControl/fn_commandControlManager.sqf
@@ -268,10 +268,12 @@ if (isServer) then {
 							", _wpIndex];
 							_wpStatement = _wpStatement + _disableWaypointStatement;
 
-							// Always use ASL — flyInHeightASL is dominant (flyInHeight=10 is just a subordinate floor)
-														private _flyInHeightStatement = format ["[group this, %1] call AIC_fnc_setWaypointFlyInHeightActionHandlerScript;
+							// Only inject fly-in-height statement if altitude is actually set on this waypoint
+														if (!isNil "_wpFlyInHeightAsl") then {
+															private _flyInHeightStatement = format ["[group this, %1] call AIC_fnc_setWaypointFlyInHeightActionHandlerScript;
 							    ", _wpFlyInHeightAsl];
-														_wpStatement = _wpStatement + _flyInHeightStatement;
+															_wpStatement = _wpStatement + _flyInHeightStatement;
+														};
 							if (!isNil "_wpTimeout") then {
 								_wpObject setWaypointTimeout [_wpTimeout, _wpTimeout, _wpTimeout];
 							};

--- a/addons/main/functions/mapElements/commandControl/fn_commandControlManager.sqf
+++ b/addons/main/functions/mapElements/commandControl/fn_commandControlManager.sqf
@@ -268,12 +268,13 @@ if (isServer) then {
 							", _wpIndex];
 							_wpStatement = _wpStatement + _disableWaypointStatement;
 
-							// Only inject fly-in-height statement if altitude is actually set on this waypoint
-														if (!isNil "_wpFlyInHeightAsl") then {
-															private _flyInHeightStatement = format ["[group this, %1] call AIC_fnc_setWaypointFlyInHeightActionHandlerScript;
-							    ", _wpFlyInHeightAsl];
-															_wpStatement = _wpStatement + _flyInHeightStatement;
-														};
+							// Stamp the native loiter altitude now so the engine does not override flyInHeightASL on loiter entry
+								if (!isNil "_wpFlyInHeightAsl") then {
+									_wpObject setWaypointLoiterAltitude _wpFlyInHeightAsl;
+									private _flyInHeightStatement = format ["[group this, %1] call AIC_fnc_setWaypointFlyInHeightActionHandlerScript;
+							", _wpFlyInHeightAsl];
+									_wpStatement = _wpStatement + _flyInHeightStatement;
+								};
 							if (!isNil "_wpTimeout") then {
 								_wpObject setWaypointTimeout [_wpTimeout, _wpTimeout, _wpTimeout];
 							};

--- a/addons/main/functions/mapElements/commandControl/fn_commandControlManager.sqf
+++ b/addons/main/functions/mapElements/commandControl/fn_commandControlManager.sqf
@@ -243,6 +243,7 @@ if (isServer) then {
 							private _wpLoiterRadius = _waypoint select AIC_Waypoint_ArrayIndex_LoiterRadius;
 							private _wpLoiterDirection = _waypoint select AIC_Waypoint_ArrayIndex_LoiterDirection;
 							private _wpFlyInHeight = _waypoint select AIC_Waypoint_ArrayIndex_FlyInHeight;
+							private _wpFlyInHeightAsl = _waypoint select AIC_Waypoint_ArrayIndex_FlyInHeightAsl;
 
 							if (_wpDuration > 0) then {
 								_priorWaypointDurationEnabled = true;
@@ -267,11 +268,16 @@ if (isServer) then {
 							", _wpIndex];
 							_wpStatement = _wpStatement + _disableWaypointStatement;
 
-							if (!isNil "_wpFlyInHeight") then {
-								private _flyInHeightStatement = format ["[group this, %1] call AIC_fnc_setWaypointFlyInHeightActionHandlerScript;
-								", _wpFlyInHeight];
-								_wpStatement = _wpStatement + _flyInHeightStatement;
-							};
+							if (!isNil "_wpFlyInHeight" && isNil "_wpFlyInHeightAsl") then {
+									private _flyInHeightStatement = format ["[group this, %1] call AIC_fnc_setWaypointFlyInHeightAglActionHandlerScript;
+    ", _wpFlyInHeight];
+									_wpStatement = _wpStatement + _flyInHeightStatement;
+								};
+								if (!isNil "_wpFlyInHeightAsl" && isNil "_wpFlyInHeight") then {
+									private _flyInHeightAslStatement = format ["[group this, %1] call AIC_fnc_setWaypointFlyInHeightAslActionHandlerScript;
+    ", _wpFlyInHeightAsl];
+									_wpStatement = _wpStatement + _flyInHeightAslStatement;
+								};
 							if (!isNil "_wpTimeout") then {
 								_wpObject setWaypointTimeout [_wpTimeout, _wpTimeout, _wpTimeout];
 							};
@@ -319,6 +325,28 @@ if (isServer) then {
 					if (_wpDuration > 0 && _group getVariable ["AIC_WP_DURATION_REMANING", 0] <= 0) then {
 						_nextActiveWaypoint set [AIC_Waypoint_ArrayIndex_Duration, 0];
 						[_group, _nextActiveWaypoint] call AIC_fnc_setWaypoint;
+					};
+
+					// Store altitude for fallback in case waypoints are lost
+					private _wpFlyInHeight = _nextActiveWaypoint select AIC_Waypoint_ArrayIndex_FlyInHeight;
+					private _wpFlyInHeightAsl = _nextActiveWaypoint select AIC_Waypoint_ArrayIndex_FlyInHeightAsl;
+					if (!isNil "_wpFlyInHeight" && isNil "_wpFlyInHeightAsl") then {
+						_group setVariable ["AIC_Last_FlyInHeight", _wpFlyInHeight];
+						_group setVariable ["AIC_Last_FlyInHeightAsl", nil];
+					};
+					if (!isNil "_wpFlyInHeightAsl" && isNil "_wpFlyInHeight") then {
+						_group setVariable ["AIC_Last_FlyInHeightAsl", _wpFlyInHeightAsl];
+						_group setVariable ["AIC_Last_FlyInHeight", nil];
+					};
+				} else {
+					// No waypoints: apply last stored altitude if available (fallback before losing waypoint)
+					private _lastFlyInHeight = _group getVariable ["AIC_Last_FlyInHeight", nil];
+					private _lastFlyInHeightAsl = _group getVariable ["AIC_Last_FlyInHeightAsl", nil];
+					if (!isNil "_lastFlyInHeight" && isNil "_lastFlyInHeightAsl") then {
+						[_group, _lastFlyInHeight] call AIC_fnc_setWaypointFlyInHeightAglActionHandlerScript;
+					};
+					if (!isNil "_lastFlyInHeightAsl" && isNil "_lastFlyInHeight") then {
+						[_group, _lastFlyInHeightAsl] call AIC_fnc_setWaypointFlyInHeightAslActionHandlerScript;
 					};
 				};
 			} forEach allGroups;

--- a/addons/main/functions/mapElements/groupControl/fn_groupControlWaypointEventHandler.sqf
+++ b/addons/main/functions/mapElements/groupControl/fn_groupControlWaypointEventHandler.sqf
@@ -49,6 +49,22 @@ if( _event == "DROPPED" ) then {
 	_position = _params select 0;
 	_waypoint set [1,_position];
 	[_group, _waypoint] call AIC_fnc_setWaypoint;
+
+	// Apply altitude immediately on waypoint move (fallback to internal if no altitude set)
+	private _wpFlyInHeight = _waypoint select AIC_Waypoint_ArrayIndex_FlyInHeight;
+	private _wpFlyInHeightAsl = _waypoint select AIC_Waypoint_ArrayIndex_FlyInHeightAsl;
+	if (isNil "_wpFlyInHeight" && isNil "_wpFlyInHeightAsl") then {
+		// No altitude set - use internal defaults (250 AGL / 250 ASL)
+		{ if (_x isKindOf "Air") then { [_x, 10] remoteExec ["flyInHeight", _x]; [_x, [10,10,10]] remoteExec ["flyInHeightASL", _x]; }; } forEach ([_group] call AIC_fnc_getGroupAssignedVehicles);
+	} else {
+		if (!isNil "_wpFlyInHeight" && isNil "_wpFlyInHeightAsl") then {
+			[_group, _wpFlyInHeight] call AIC_fnc_setWaypointFlyInHeightAglActionHandlerScript;
+		};
+		if (!isNil "_wpFlyInHeightAsl" && isNil "_wpFlyInHeight") then {
+			[_group, _wpFlyInHeightAsl] call AIC_fnc_setWaypointFlyInHeightAslActionHandlerScript;
+		};
+	};
+
 	[_groupControlId,"REFRESH_WAYPOINTS",[]] call AIC_fnc_groupControlEventHandler;
 };
 

--- a/addons/main/functions/mapElements/groupControl/fn_groupControlWaypointEventHandler.sqf
+++ b/addons/main/functions/mapElements/groupControl/fn_groupControlWaypointEventHandler.sqf
@@ -50,19 +50,10 @@ if( _event == "DROPPED" ) then {
 	_waypoint set [1,_position];
 	[_group, _waypoint] call AIC_fnc_setWaypoint;
 
-	// Apply altitude immediately on waypoint move (fallback to internal if no altitude set)
-	private _wpFlyInHeight = _waypoint select AIC_Waypoint_ArrayIndex_FlyInHeight;
+	// Apply altitude immediately on waypoint move (always ASL)
 	private _wpFlyInHeightAsl = _waypoint select AIC_Waypoint_ArrayIndex_FlyInHeightAsl;
-	if (isNil "_wpFlyInHeight" && isNil "_wpFlyInHeightAsl") then {
-		// No altitude set - use internal defaults (250 AGL / 250 ASL)
-		{ if (_x isKindOf "Air") then { [_x, 10] remoteExec ["flyInHeight", _x]; [_x, [10,10,10]] remoteExec ["flyInHeightASL", _x]; }; } forEach ([_group] call AIC_fnc_getGroupAssignedVehicles);
-	} else {
-		if (!isNil "_wpFlyInHeight" && isNil "_wpFlyInHeightAsl") then {
-			[_group, _wpFlyInHeight] call AIC_fnc_setWaypointFlyInHeightAglActionHandlerScript;
-		};
-		if (!isNil "_wpFlyInHeightAsl" && isNil "_wpFlyInHeight") then {
-			[_group, _wpFlyInHeightAsl] call AIC_fnc_setWaypointFlyInHeightAslActionHandlerScript;
-		};
+	if (!isNil "_wpFlyInHeightAsl") then {
+		[_group, _wpFlyInHeightAsl] call AIC_fnc_setWaypointFlyInHeightActionHandlerScript;
 	};
 
 	[_groupControlId,"REFRESH_WAYPOINTS",[]] call AIC_fnc_groupControlEventHandler;

--- a/addons/main/functions/mapElements/groupControl/fn_showGroupWaypointReport.sqf
+++ b/addons/main/functions/mapElements/groupControl/fn_showGroupWaypointReport.sqf
@@ -20,12 +20,8 @@ if(_wpDuration > 0) then {
 	_wpInfo = _wpInfo + format [_textSmall,"Duration (mins)", (str floor (_wpDuration/60)) ,_sizeSmall];
 };
 
-if(!isNil "_wpFlyInHeight") then {
-	_wpInfo = _wpInfo + format [_textSmall,"Height (meters, AGL)", _wpFlyInHeight,_sizeSmall];
-};
-
 if(!isNil "_wpFlyInHeightAsl") then {
-	_wpInfo = _wpInfo + format [_textSmall,"Height (meters, ASL)", _wpFlyInHeightAsl,_sizeSmall];
+	_wpInfo = _wpInfo + format [_textSmall,"Height (meters ASL)", _wpFlyInHeightAsl,_sizeSmall];
 };
 
 _text = parseText (

--- a/addons/main/functions/mapElements/groupControl/fn_showGroupWaypointReport.sqf
+++ b/addons/main/functions/mapElements/groupControl/fn_showGroupWaypointReport.sqf
@@ -3,7 +3,7 @@
 params ["_groupControlId","_waypointId"];
 _group = [_groupControlId] call AIC_fnc_getGroupControlGroup;
 _waypoint = [_group, _waypointId] call AIC_fnc_getWaypoint;
-_waypoint params ["_wpIndex","_wpPosition","_wpDisabled",["_wpType","MOVE"],["_wpActionScript",""],["_wpCondition","true"],"_wpTimeout","_wpFormation","_wpCompletionRadius",["_wpDuration",0],"_wpLoiterRadius","_wpLoiterDirection","_wpFlyInHeight"];
+_waypoint params ["_wpIndex","_wpPosition","_wpDisabled",["_wpType","MOVE"],["_wpActionScript",""],["_wpCondition","true"],"_wpTimeout","_wpFormation","_wpCompletionRadius",["_wpDuration",0],"_wpLoiterRadius","_wpLoiterDirection","_wpFlyInHeight","_wpFlyInHeightAsl"];
 							
 _sizeLarge = 1.0;
 _sizeSmall = 0.9;
@@ -21,7 +21,11 @@ if(_wpDuration > 0) then {
 };
 
 if(!isNil "_wpFlyInHeight") then {
-	_wpInfo = _wpInfo + format [_textSmall,"Height (meters)", _wpFlyInHeight,_sizeSmall];
+	_wpInfo = _wpInfo + format [_textSmall,"Height (meters, AGL)", _wpFlyInHeight,_sizeSmall];
+};
+
+if(!isNil "_wpFlyInHeightAsl") then {
+	_wpInfo = _wpInfo + format [_textSmall,"Height (meters, ASL)", _wpFlyInHeightAsl,_sizeSmall];
 };
 
 _text = parseText (


### PR DESCRIPTION
## Fixes Issue #6

Adds "fly in height above sea level" (ASL) options alongside existing "above ground level" (AGL) options for aircraft groups and waypoints.

### Problem
When setting loiter altitude for aircraft, the selected altitude was from ground level (AGL) rather than sea level (ASL). This caused aircraft to raise and lower with terrain, throwing off gunnery and target acquisition.

### Solution
Exploits Arma engine behavior: `final = max(flyInHeight, flyInHeightASL)` — higher value wins.

- **AGL mode**: `flyInHeight = target`, `flyInHeightASL = [10,10,10]` → AGL wins
- **ASL mode**: `flyInHeight = 10`, `flyInHeightASL = [target,target,target]` → ASL wins

### Files changed
- `waypoint.h`: Added `AIC_Waypoint_ArrayIndex_FlyInHeightAsl` index 13
- `fn_commandMenuActionsInit.sqf`: Group and waypoint handlers split into AGL/ASL variants with 12 altitude options each
- `fn_commandControlManager.sqf`: Waypoint activation calls correct handler
- `fn_showGroupWaypointReport.sqf`: Display shows AGL vs ASL label
- `fn_toStringWaypoint.sqf`: Logging for new ASL index